### PR TITLE
 various bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Examples:
 ### as a library
 
 ```javascript
-const dna = require('dna-to-openapi')
+const dna = require('@holochain/dna-to-openapi')
 
 // 1 - lint
 const lintResults = dna.lint(dnaJsonObject, schemasObject)

--- a/lib/bundle-dna.js
+++ b/lib/bundle-dna.js
@@ -71,6 +71,14 @@ exports.bundleDna = function bundleDna (appDir) {
       }
       fetchSchema(zome.Name, entry.SchemaFile)
     }
+    for (let fn of zome.Functions) {
+      if ('InputSchemaFile' in fn) {
+        fetchSchema(zome.Name, fn.InputSchemaFile)
+      }
+      if ('OutputSchemaFile' in fn) {
+        fetchSchema(zome.Name, fn.OutputSchemaFile)
+      }
+    }
   }
 
   return {

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -2,6 +2,7 @@
 
 const lint = require('./dna-lint').lint
 const _get = require('./util').get
+const version = require('../package').version
 
 /**
  * @param {object} opts
@@ -14,7 +15,13 @@ function _genTop (opts) {
     openapi: '3.0.0',
     info: {
       title: opts.title,
-      description: opts.description,
+      description: opts.description + `
+
+## usage
+This documentation was auto-generated from the application's dna file using [dna-to-openapi](https://www.npmjs.com/package/@holochain/dna-to-openapi).
+
+dna-to-openapi version ${version}
+`,
       version: opts.version
     },
     servers: [
@@ -25,7 +32,7 @@ function _genTop (opts) {
             default: '127.0.0.1'
           },
           port: {
-            default: '10001'
+            default: '4141'
           }
         }
       }
@@ -60,6 +67,10 @@ function _genPath (opts) {
     summary: opts.summary,
     consumes: [opts.consumes],
     produces: [opts.produces]
+  }
+
+  if (opts.description) {
+    out.description = opts.description
   }
 
   if (opts.consumes === 'application/json') {
@@ -110,6 +121,22 @@ function _genPath (opts) {
     }
   }
 
+  out.responses.default = {
+    description: 'Error',
+    content: {
+      'application/json': {
+        schema: {
+          type: 'object'
+        }
+      },
+      'text/plain': {
+        schema: {
+          type: 'string'
+        }
+      }
+    }
+  }
+
   return {
     post: out
   }
@@ -150,14 +177,21 @@ exports.convert = function convert (dna, opts) {
         outSchema = schemas[outSchema]
       }
 
-      out.result.paths['/' + zname + '/' + fname] = _genPath({
+      const pathSpec = {
         tags: [zname],
-        summary: _get(zome, 'Description', '') + ' ' + fname,
+        summary: fname,
         consumes: consumes,
         produces: produces,
         inSchema: inSchema,
         outSchema: outSchema
-      })
+      }
+
+      if (typeof fn.Description === 'string') {
+        pathSpec.description = fn.Description
+        pathSpec.summary = pathSpec.description.split('\n')[0]
+      }
+
+      out.result.paths['/' + zname + '/' + fname] = _genPath(pathSpec)
     }
   }
 

--- a/lib/convert.test.js
+++ b/lib/convert.test.js
@@ -23,6 +23,7 @@ const BASIC = {
 const BASIC_STRING = JSON.parse(JSON.stringify(BASIC))
 BASIC_STRING.Zomes[0].Functions.push({
   Name: 'test',
+  Description: 'test',
   CallingType: 'string',
   ReturnType: 'string'
 })
@@ -47,7 +48,7 @@ const BASIC_RESULT = {
   'openapi': '3.0.0',
   'info': {
     'title': 'test',
-    'description': 'test',
+    'description': 'removed',
     'version': 1
   },
   'servers': 'removed',
@@ -63,7 +64,8 @@ BASIC_RESULT_STRING.paths['/test/test'].post = {
   'tags': [
     'test'
   ],
-  'summary': 'test test',
+  'summary': 'test',
+  'description': 'test',
   'consumes': [
     'text/plain'
   ],
@@ -90,6 +92,21 @@ BASIC_RESULT_STRING.paths['/test/test'].post = {
           }
         }
       }
+    },
+    'default': {
+      'content': {
+        'application/json': {
+          'schema': {
+            'type': 'object'
+          }
+        },
+        'text/plain': {
+          'schema': {
+            'type': 'string'
+          }
+        }
+      },
+      'description': 'Error'
     }
   }
 }
@@ -99,7 +116,7 @@ BASIC_RESULT_JSON.paths['/test/test'].post = {
   'tags': [
     'test'
   ],
-  'summary': 'test test',
+  'summary': 'test',
   'consumes': [
     'application/json'
   ],
@@ -138,6 +155,21 @@ BASIC_RESULT_JSON.paths['/test/test'].post = {
           }
         }
       }
+    },
+    'default': {
+      'content': {
+        'application/json': {
+          'schema': {
+            'type': 'object'
+          }
+        },
+        'text/plain': {
+          'schema': {
+            'type': 'string'
+          }
+        }
+      },
+      'description': 'Error'
     }
   }
 }
@@ -147,7 +179,7 @@ CUSTOM_RESULT_JSON.paths['/test/test'].post = {
   'tags': [
     'test'
   ],
-  'summary': 'test test',
+  'summary': 'test',
   'consumes': [
     'application/json'
   ],
@@ -178,33 +210,54 @@ CUSTOM_RESULT_JSON.paths['/test/test'].post = {
           }
         }
       }
+    },
+    'default': {
+      'content': {
+        'application/json': {
+          'schema': {
+            'type': 'object'
+          }
+        },
+        'text/plain': {
+          'schema': {
+            'type': 'string'
+          }
+        }
+      },
+      'description': 'Error'
     }
   }
 }
 
 describe('dna-to-openapi Suite', () => {
+  let res
+
+  const exec = function exec (dna, opts) {
+    res = lib.convert(dna, opts)
+    res.result.info.description = 'removed'
+    res.result.servers = 'removed'
+  }
+
   it('convert is a function', () => {
     expect(typeof lib.convert).equals('function')
   })
 
   it('should generate basic string types', () => {
-    const res = lib.convert(BASIC_STRING, {
+    exec(BASIC_STRING, {
       schemas: {}
     })
-    res.result.servers = 'removed'
     expect(res.result).deep.equals(BASIC_RESULT_STRING)
   })
 
   it('should generate basic json types (default schema)', () => {
-    const res = lib.convert(BASIC_JSON, {
+    exec(BASIC_JSON, {
       schemas: {}
     })
-    res.result.servers = 'removed'
     expect(res.result).deep.equals(BASIC_RESULT_JSON)
   })
 
   it('should generate basic json types (custom schema)', () => {
-    const res = lib.convert(CUSTOM_JSON, {
+    exec(CUSTOM_JSON, {
       schemas: {
         test: {
           'test.json': {
@@ -215,7 +268,6 @@ describe('dna-to-openapi Suite', () => {
         }
       }
     })
-    res.result.servers = 'removed'
     expect(res.result).deep.equals(CUSTOM_RESULT_JSON)
   })
 })

--- a/lib/dna-lint.js
+++ b/lib/dna-lint.js
@@ -47,9 +47,6 @@ exports.lint = function lint (dna, opts) {
     if (!schema || typeof schema !== 'object') {
       return
     }
-    lvl(schema.type === 'object', 'schema.type must be "object"', sname)
-    lvl(typeof schema.properties === 'object',
-      'schema.properties must be an object', sname)
 
     if (Array.isArray(schema.required)) {
       for (let required of schema.required) {

--- a/lib/dna-lint.test.js
+++ b/lib/dna-lint.test.js
@@ -215,12 +215,6 @@ describe('dna-lint Suite', () => {
         expect(res.errors.length).equals(1)
       })
 
-      it('should error if bad type', () => {
-        opts.schemas.Z1['test.json'].type = 'bad'
-        _exec()
-        expect(res.errors.length).equals(1)
-      })
-
       it('should error if bad required', () => {
         opts.schemas.Z1['test.json'].required = ['bad']
         _exec()

--- a/lib/gen-docs.js
+++ b/lib/gen-docs.js
@@ -59,7 +59,7 @@ exports.genDocs = function genDocs (openapi) {
       window.onload = function() {
         const spec = `
 
-  out += openapi
+  out += JSON.stringify(openapi, null, '  ')
 
   out += `
         // Build a system

--- a/lib/gen-docs.test.js
+++ b/lib/gen-docs.test.js
@@ -4,6 +4,12 @@ const expect = require('chai').expect
 
 const lib = require('./index')
 
+const RE_UI_MATCH = [
+  /<!DOCTYPE html>/,
+  /fake-spec/,
+  /#swagger-ui/
+]
+
 describe('gen-docs Suite', () => {
   it('should be a function', () => {
     expect(typeof lib.genDocs).equals('function')
@@ -11,7 +17,10 @@ describe('gen-docs Suite', () => {
 
   it('should generate swagger-ui', () => {
     const ui = lib.genDocs({ test: 'fake-spec' })
-    expect(ui.substr(0, 1000)).contains('<!DOCTYPE html>')
-    expect(ui.substr(ui.length - 1000)).contains('#swagger-ui')
+    // turns out expect().contains() is way to slow for this large a string
+    // use regexes instead
+    for (let re of RE_UI_MATCH) {
+      expect(re.test(ui)).equals(true, 'did not match ' + re.toString())
+    }
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dna-to-openapi",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "@holochain/dna-to-openapi",
   "version": "0.0.3",
   "description": "given holochain dna, generate a swagger / openapi spec file / static swagger-ui html documentation",
+  "keywords": [
+    "holo",
+    "holochain",
+    "openapi",
+    "blockchain",
+    "api",
+    "documentation"
+  ],
   "repository": {
     "type": "git",
     "url": "github:holochain/dna-to-openapi.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/dna-to-openapi",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "description": "given holochain dna, generate a swagger / openapi spec file / static swagger-ui html documentation",
   "keywords": [
     "holo",


### PR DESCRIPTION
- load function-based schema references
- use hcdev default port
- add default Error response schemas
- function descriptions (first line as summary)
- allow non-object json schemas (e.g. arrays)
- actually put the openapi spec in the docs ([object Object])